### PR TITLE
Get correctly ordered log

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Please do `sudo apt-get -y autoremove --purge 'linux-.*generic'` again after reb
 ### Install Astra Camera
 
 Please follow [jsk_recognition documentation](https://jsk-recognition.readthedocs.io/en/latest/install_astra_camera.html).
+
 ### Install C/C++ Library in libmraa
 
 ```bash
@@ -27,6 +28,7 @@ Details are on [GitHub page](https://github.com/intel-iot-devkit/mraa).
 ### Install sphand_ros and its dependencies
 
 ```bash
+sudo apt-get install tmux
 mkdir -p ~/apc_ws/src
 cd ~/apc_ws/src
 git clone https://github.com/pazeshun/sphand_ros.git
@@ -113,18 +115,28 @@ I2C Block Read                   yes
 
 ## Usage
 
-### How to kill and restart roslaunch
+### How to restart roslaunch
 
 ```bash
-# Kill
-sudo service supervisor stop  # Or {sudo supervisorctl shutdown}
-kill <roslaunch_pid>  # Get pid by {ps aux | grep roslaunch}
-# Restart
-sudo service supervisor start
+sudo service supervisor restart  # Or {sudo supervisorctl restart}
 ```
 
-### How to see stdout/stderr from roslaunch
+### How to access roslaunch terminal
 
 ```bash
-cat /var/log/supervisor/LaunchLeftGripper.log
+# Be careful to use this, because this session is killed when logger daemon is killed or roslaunch daemon is restarted
+tmux attach -t gripper
+```
+
+### How to see stdout/stderr from roslaunch dropped from tmux
+
+```bash
+cat /var/log/supervisor/LaunchLogger.log
+```
+
+### How to see other logs
+
+```bash
+cat /var/log/supervisor/CheckI2cdetect.log  # Log of I2C interface recognition test
+cat /var/log/supervisor/LaunchLeftGripper.log  # Log of preprocess for roslaunch (e.g., network checking)
 ```

--- a/sphand_driver/scripts/create_supervisor_conf
+++ b/sphand_driver/scripts/create_supervisor_conf
@@ -7,3 +7,4 @@ echo ""
 
 sudo cp `rospack find sphand_driver`/supervisor/launch_left_gripper.conf /etc/supervisor/conf.d
 sudo cp `rospack find sphand_driver`/supervisor/check_i2cdetect.conf /etc/supervisor/conf.d
+sudo cp `rospack find sphand_driver`/supervisor/launch_logger.conf /etc/supervisor/conf.d

--- a/sphand_driver/scripts/launch_left_gripper.sh
+++ b/sphand_driver/scripts/launch_left_gripper.sh
@@ -15,8 +15,7 @@ tmux kill-session -t gripper
 
 # roslaunch in tmux
 set -e
-tmux new-session -d -s gripper -n roslaunch
-tmux send-keys -t gripper:roslaunch.0 "script -f /tmp/supervisor/launch_logger_fifo" Enter
+tmux new-session -d -s gripper -n roslaunch "script -f /tmp/supervisor/launch_logger_fifo"
 ## Using pipe-pane like following does not work when -d is specified in new-session:
 ## tmux pipe-pane -o -t gripper:roslaunch.0 "cat > /tmp/supervisor/launch_logger_fifo"
 ## capture-pane works, but it only captures current state and does not know which line is new

--- a/sphand_driver/scripts/launch_left_gripper.sh
+++ b/sphand_driver/scripts/launch_left_gripper.sh
@@ -6,7 +6,7 @@ do
   sleep 1
 done
 
-# Prepare FIFO for logging
+# Prepare FIFO for logging. Perhaps this FIFO is already prepared by LaunchLogger
 mkdir /tmp/supervisor
 mkfifo /tmp/supervisor/launch_logger_fifo
 

--- a/sphand_driver/scripts/launch_left_gripper.sh
+++ b/sphand_driver/scripts/launch_left_gripper.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Wait until network is ready
+while ! ping -c 1 baxter > /dev/null
+do
+  sleep 1
+done
+
+# roslaunch
+set -e
+source ~/apc_ws/devel/setup.bash
+rossetip
+rossetmaster baxter
+roslaunch sphand_driver setup_gripper_v8.launch left_gripper:=true

--- a/sphand_driver/scripts/launch_left_gripper.sh
+++ b/sphand_driver/scripts/launch_left_gripper.sh
@@ -6,9 +6,15 @@ do
   sleep 1
 done
 
-# roslaunch
+# Prepare FIFO for logging
+mkdir /tmp/supervisor
+mkfifo /tmp/supervisor/launch_logger_fifo
+
+# roslaunch in tmux
 set -e
-source ~/apc_ws/devel/setup.bash
-rossetip
-rossetmaster baxter
-roslaunch sphand_driver setup_gripper_v8.launch left_gripper:=true
+tmux new-session -d -s gripper -n roslaunch
+tmux send-keys -t gripper:roslaunch.0 "script -f /tmp/supervisor/launch_logger_fifo" Enter
+## Using pipe-pane like following does not work when -d is specified in new-session:
+## tmux pipe-pane -o -t gripper:roslaunch.0 "cat > /tmp/supervisor/launch_logger_fifo"
+## capture-pane works, but it only captures current state and does not know which line is new
+tmux send-keys -t gripper:roslaunch.0 "source ~/apc_ws/devel/setup.bash && rossetip && rossetmaster baxter && roslaunch sphand_driver setup_gripper_v8.launch left_gripper:=true" Enter

--- a/sphand_driver/scripts/launch_left_gripper.sh
+++ b/sphand_driver/scripts/launch_left_gripper.sh
@@ -10,6 +10,9 @@ done
 mkdir /tmp/supervisor
 mkfifo /tmp/supervisor/launch_logger_fifo
 
+# Kill previous roslaunch
+tmux kill-session -t gripper
+
 # roslaunch in tmux
 set -e
 tmux new-session -d -s gripper -n roslaunch

--- a/sphand_driver/supervisor/check_i2cdetect.conf
+++ b/sphand_driver/supervisor/check_i2cdetect.conf
@@ -1,6 +1,6 @@
 [program:CheckI2cdetect]
 user=root
-command=/bin/bash -c 'RES=$(i2cdetect -F 1); echo $RES | grep no; if [ $? = 0 ]; then echo "i2cdetect outputs correctly"; else echo "i2cdetect outputs wrongly, so reboot"; reboot; fi'
+command=/bin/bash -c 'date; RES=$(i2cdetect -F 1); echo $RES | grep no; if [ $? = 0 ]; then echo "i2cdetect outputs correctly"; else echo "i2cdetect outputs wrongly, so reboot"; reboot; fi'
 autostart=true
 autorestart=false
 startsecs=0

--- a/sphand_driver/supervisor/launch_left_gripper.conf
+++ b/sphand_driver/supervisor/launch_left_gripper.conf
@@ -3,6 +3,7 @@ user=pazeshun
 command=/bin/bash -c 'source ~/apc_ws/devel/setup.bash && $(rospack find sphand_driver)/scripts/launch_left_gripper.sh'
 autostart=true
 autorestart=false
+startsecs=0
 redirect_stderr=true
 stdout_logfile=/var/log/supervisor/LaunchLeftGripper.log
 stdout_logfile_maxbytes=1MB

--- a/sphand_driver/supervisor/launch_left_gripper.conf
+++ b/sphand_driver/supervisor/launch_left_gripper.conf
@@ -1,6 +1,6 @@
 [program:LaunchLeftGripper]
 user=pazeshun
-command=/bin/bash -c 'while ! ping -c 1 baxter > /dev/null; do sleep 1; done && source ~/apc_ws/devel/setup.bash && rossetip && rossetmaster baxter && roslaunch sphand_driver setup_gripper_v8.launch left_gripper:=true'
+command=/bin/bash -c 'source ~/apc_ws/devel/setup.bash && $(rospack find sphand_driver)/scripts/launch_left_gripper.sh'
 autostart=true
 autorestart=false
 redirect_stderr=true

--- a/sphand_driver/supervisor/launch_left_gripper.conf
+++ b/sphand_driver/supervisor/launch_left_gripper.conf
@@ -1,6 +1,6 @@
 [program:LaunchLeftGripper]
 user=pazeshun
-command=/bin/bash -c 'source ~/apc_ws/devel/setup.bash && $(rospack find sphand_driver)/scripts/launch_left_gripper.sh'
+command=/bin/bash -c 'date; source ~/apc_ws/devel/setup.bash && $(rospack find sphand_driver)/scripts/launch_left_gripper.sh'
 autostart=true
 autorestart=false
 startsecs=0

--- a/sphand_driver/supervisor/launch_logger.conf
+++ b/sphand_driver/supervisor/launch_logger.conf
@@ -1,6 +1,6 @@
 [program:LaunchLogger]
 user=pazeshun
-command=/bin/bash -c 'mkdir /tmp/supervisor; mkfifo /tmp/supervisor/launch_logger_fifo; while :; do cat /tmp/supervisor/launch_logger_fifo; done'
+command=/bin/bash -c 'date; mkdir /tmp/supervisor; mkfifo /tmp/supervisor/launch_logger_fifo; while :; do cat /tmp/supervisor/launch_logger_fifo; done'
 ;; Looping is required because cat exits when script command in launch_left_gripper is killed
 autostart=true
 autorestart=false

--- a/sphand_driver/supervisor/launch_logger.conf
+++ b/sphand_driver/supervisor/launch_logger.conf
@@ -1,0 +1,10 @@
+[program:LaunchLogger]
+user=pazeshun
+command=/bin/bash -c 'mkdir /tmp/supervisor; mkfifo /tmp/supervisor/launch_logger_fifo; while :; do cat /tmp/supervisor/launch_logger_fifo; done'
+;; Looping is required because cat exits when script command in launch_left_gripper is killed
+autostart=true
+autorestart=false
+redirect_stderr=true
+stdout_logfile=/var/log/supervisor/LaunchLogger.log
+stdout_logfile_maxbytes=1MB
+stdout_logfile_backups=5


### PR DESCRIPTION
Previous log's order is sometimes strange and some lines are destroyed by overwriting.
(ex. 1):
```
NODES
  /gripper_front/limb/left/dxl/
    controller_manager (dynamixel_controllers/controller_manager.py)
    controller_spawner (dynamixel_controllers/controller_spawner.py)
  /left_hand_camera_raw/left/
    driver (nodelet/nodelet)
    left_nodelet_manager (nodelet/nodelet)
  /left_hand_camera_raw/right/
    driver (nodelet/nodelet)
    right_nodelet_manager (nodelet/nodelet)
  /
    adjust_c[ERROR] [1556620876.132982492]: No valid hardware interface element found in joint 'right_s0'.
[ERROR] [1556620876.133398246]: Failed to load joints for transmission 'right_tran1'.
[ERROR] [1556620876.133717330]: No valid hardware interface element found in joint 'right_s1'.
```
(ex. 2):
```
[ERROR] [1556620970.146436362]: Failed to reset VL53L0X No. 2
[ERROR] [1556620970.155308873]: Failed to reset VL53L0X No. 2
[ERROR] [1556620970.164032979]: Failed to reset VL53L0X No. 2
tialize all I2C sensors
[ INFO] [1556620969.679909399]: Try to re-initialize all I2C sensors
[ INFO] [1556620969.689989611]: Try to re-initialize all I2C sensors
[ INFO] [1556620969.700284025]: Try to re-initialize all I2C sensors
```

This seems due to redirecting roslaunch to log file:
https://answers.ros.org/question/245566/redirecting-roslaunch-output-to-log-file/

So I used `tmux` to see correct display.
This PR keeps logging to log file even though roslaunch's output is inside `tmux`.